### PR TITLE
[FIX] product_extended: bom_count shows 0

### DIFF
--- a/addons/product_extended/product_extended_view.xml
+++ b/addons/product_extended/product_extended_view.xml
@@ -9,7 +9,6 @@
             <field name="groups_id" eval="[(4, ref('mrp.group_mrp_user'))]"/>
             <field name="arch" type="xml">
                 <div name="standard_price_uom" position="after">
-                    <field name="bom_count" invisible="1"/>
                     <button name="%(action_view_compute_price_wizard)d"
                         string="Compute from BOM" type="action" 
                         attrs="{'invisible': ['|', ('cost_method', '!=', 'standard'), ('bom_count', '=', 0)]}"


### PR DESCRIPTION
The field bom_count appeared twice in product.template form view and
then the smart button for "Bill of Materials" always displayed 0 as
number of BoMs.

opw:681830
(cherry picked from commit 31fb5275fd037f0edfcbe6cb4a10802761171d8b)

